### PR TITLE
fix: update npm package name to match org

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# @gomessaging/nats
+# @sparetimecoders/messaging-nats
 
 <p align="center">
   <strong>NATS/JetStream transport for gomessaging (Node.js/TypeScript).</strong>
@@ -6,7 +6,7 @@
 
 <p align="center">
   <a href="https://github.com/sparetimecoders/nodejs-messaging-nats/actions"><img alt="CI" src="https://github.com/sparetimecoders/nodejs-messaging-nats/actions/workflows/ci.yml/badge.svg"></a>
-  <a href="https://www.npmjs.com/package/@gomessaging/nats"><img alt="npm" src="https://img.shields.io/npm/v/@gomessaging/nats"></a>
+  <a href="https://www.npmjs.com/package/@sparetimecoders/messaging-nats"><img alt="npm" src="https://img.shields.io/npm/v/@sparetimecoders/messaging-nats"></a>
   <a href="LICENSE"><img alt="License: MIT" src="https://img.shields.io/badge/license-MIT-blue.svg"></a>
 </p>
 
@@ -17,13 +17,13 @@ NATS transport implementation for the [gomessaging](https://github.com/sparetime
 ## Installation
 
 ```bash
-npm install @gomessaging/nats
+npm install @sparetimecoders/messaging-nats
 ```
 
 ## Quick Start
 
 ```typescript
-import { Connection } from "@gomessaging/nats";
+import { Connection } from "@sparetimecoders/messaging-nats";
 
 const conn = new Connection({
   url: "nats://localhost:4222",
@@ -48,7 +48,7 @@ await pub.publish("Order.Created", { orderId: "abc-123", amount: 42 });
 Publish domain events to the default `events` JetStream stream. Any number of services can subscribe by routing key. Consumers are durable by default (survive restarts); pass `ephemeral: true` for transient subscriptions.
 
 ```typescript
-import { Connection } from "@gomessaging/nats";
+import { Connection } from "@sparetimecoders/messaging-nats";
 
 const conn = new Connection({
   url: "nats://localhost:4222",
@@ -181,7 +181,7 @@ interface StreamConfig {
 Use `streamDefaults` to apply limits to all streams, and `streamConfigs` for per-stream overrides. Per-stream configs replace defaults entirely (no field-level merging).
 
 ```typescript
-import { Connection, DefaultStreamConfig } from "@gomessaging/nats";
+import { Connection, DefaultStreamConfig } from "@sparetimecoders/messaging-nats";
 
 const conn = new Connection({
   url: "nats://localhost:4222",
@@ -232,7 +232,7 @@ OpenTelemetry trace context propagation is built in. Pass a `TextMapPropagator` 
 Trace context is injected into NATS headers on publish and extracted on consume. The helper functions are also exported for direct use:
 
 ```typescript
-import { injectToHeaders, extractToContext } from "@gomessaging/nats";
+import { injectToHeaders, extractToContext } from "@sparetimecoders/messaging-nats";
 
 // Inject OTel context into NATS headers
 injectToHeaders(otelContext, natsHeaders, propagator);

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,18 @@
+# @sparetimecoders/messaging-nats Documentation
+
+Detailed guides for the Node.js NATS/JetStream transport. For a quick overview, see the [main README](../README.md).
+
+| Guide | Description |
+|-------|-------------|
+| [Connection & Configuration](connection.md) | Creating connections, all options, lifecycle |
+| [Consumers](consumers.md) | Durable and ephemeral consumers, error handling, redelivery |
+| [Publishers](publishers.md) | Publishing messages, custom headers |
+| [Request-Response](request-response.md) | Synchronous RPC using Core NATS |
+| [Streams & Retention](streams.md) | JetStream stream configuration, retention policies |
+| [Observability](observability.md) | Tracing, metrics, notifications |
+
+## Related
+
+- [gomessaging specification](https://github.com/sparetimecoders/messaging) — shared spec, TCK, validation, visualization
+- [gomessaging/nats (Go)](https://github.com/sparetimecoders/go-messaging-nats) — Go NATS transport
+- [@sparetimecoders/messaging-amqp](https://github.com/sparetimecoders/nodejs-messaging-amqp) — Node.js AMQP transport

--- a/docs/connection.md
+++ b/docs/connection.md
@@ -1,0 +1,116 @@
+# Connection & Configuration
+
+## Creating a Connection
+
+```typescript
+import { Connection } from "@sparetimecoders/messaging-nats";
+
+const conn = new Connection({
+  url: "nats://localhost:4222",
+  serviceName: "order-service",
+});
+```
+
+Register publishers and consumers before calling `start()`:
+
+```typescript
+const pub = conn.addEventPublisher();
+
+conn.addEventConsumer<OrderCreated>("Order.Created", async (event) => {
+  console.log(event.payload.orderId);
+});
+
+await conn.start();
+```
+
+## Connection Options
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `url` | `string` | required | NATS server URL |
+| `serviceName` | `string` | required | Service name for consumer/subject naming |
+| `logger` | `Logger` | `console` | Logger with `info`, `warn`, `error`, `debug` |
+| `propagator` | `TextMapPropagator` | global OTel | OpenTelemetry trace context propagator |
+| `requestTimeout` | `number` | `30000` | Timeout for Core NATS request-reply (ms) |
+| `streamDefaults` | `StreamConfig` | `{}` | Default retention limits for all streams |
+| `streamConfigs` | `Record<string, StreamConfig>` | `{}` | Per-stream retention overrides |
+| `consumerDefaults` | `ConsumerDefaults` | `{}` | Default MaxDeliver and BackOff |
+| `onNotification` | `NotificationHandler` | — | Callback after handler success |
+| `onError` | `ErrorNotificationHandler` | — | Callback after handler failure |
+| `metrics` | `MetricsRecorder` | — | Metrics recorder for instrumentation |
+| `routingKeyMapper` | `RoutingKeyMapper` | — | Normalize routing keys for metrics labels |
+| `natsOptions` | `Partial<NatsConnectionOptions>` | `{}` | Pass-through options for NATS client |
+| `onReconnect` | `() => void` | — | Callback on reconnection |
+| `onDisconnect` | `(error: Error) => void` | — | Callback on disconnection |
+
+## Startup Sequence
+
+`start()` performs these steps:
+
+1. Connects to the NATS server
+2. Creates a JetStream management context
+3. Creates or updates JetStream streams with configured retention
+4. Creates durable consumers with filter subjects
+5. Subscribes to Core NATS subjects for request-reply
+6. Starts consuming messages
+
+## Connection Monitoring
+
+```typescript
+const conn = new Connection({
+  url: "nats://localhost:4222",
+  serviceName: "order-service",
+  onDisconnect: (err) => {
+    console.error("disconnected:", err.message);
+  },
+  onReconnect: () => {
+    console.log("reconnected");
+  },
+});
+```
+
+NATS has built-in reconnection. Unlike AMQP, disconnects are often transient — the client reconnects automatically.
+
+### Pass-Through NATS Options
+
+Configure reconnection behavior, TLS, authentication via `natsOptions`:
+
+```typescript
+const conn = new Connection({
+  url: "nats://localhost:4222",
+  serviceName: "order-service",
+  natsOptions: {
+    maxReconnectAttempts: 10,
+    reconnectTimeWait: 2000,
+    tls: { caFile: "/path/to/ca.pem" },
+  },
+});
+```
+
+## Graceful Shutdown
+
+```typescript
+process.on("SIGTERM", async () => {
+  await conn.close();
+});
+```
+
+`close()` drains the NATS connection — it waits for in-flight messages to finish processing before disconnecting.
+
+## Topology Export
+
+Inspect declared topology without connecting:
+
+```typescript
+const topology = conn.topology();
+// { transport: "nats", serviceName: "order-service", endpoints: [...] }
+```
+
+Use with the spec module:
+
+```typescript
+import { validate, mermaid } from "@gomessaging/spec";
+
+const errors = validate(topology);
+const diagram = mermaid([topology]);
+```

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -1,0 +1,103 @@
+# Observability
+
+## Tracing
+
+Trace context propagates through NATS message headers using OpenTelemetry.
+
+### Setup
+
+```typescript
+const conn = new Connection({
+  url: "nats://localhost:4222",
+  serviceName: "order-service",
+  propagator: myPropagator,
+});
+```
+
+Default: globally registered OpenTelemetry propagator.
+
+### Exported Helpers
+
+```typescript
+import { injectToHeaders, extractToContext } from "@sparetimecoders/messaging-nats";
+
+// Inject active span into NATS headers
+const headers = injectToHeaders(context.active(), natsHeaders);
+
+// Extract span context from received headers
+const ctx = extractToContext(msg.headers);
+```
+
+## Metrics
+
+Implement the `MetricsRecorder` interface from `@gomessaging/spec`:
+
+```typescript
+import { MetricsRecorder } from "@gomessaging/spec";
+
+const metrics: MetricsRecorder = {
+  publishSucceed(stream, routingKey, durationMs) { /* counter++ */ },
+  publishFailed(stream, routingKey, durationMs) { /* counter++ */ },
+  eventReceived(consumer, routingKey) { /* counter++ */ },
+  eventAck(consumer, routingKey, durationMs) { /* counter++ */ },
+  eventNack(consumer, routingKey, durationMs) { /* counter++ */ },
+  eventNotParsable(consumer, routingKey) { /* counter++ */ },
+  eventWithoutHandler(consumer, routingKey) { /* counter++ */ },
+};
+
+const conn = new Connection({
+  url: "nats://localhost:4222",
+  serviceName: "order-service",
+  metrics,
+  routingKeyMapper: (key) => key.replace(/[a-f0-9-]{36}/g, "<id>"),
+});
+```
+
+### Routing Key Mapper
+
+Normalize dynamic routing key segments before they become metric labels:
+
+```typescript
+routingKeyMapper: (key) => key.replace(/[a-f0-9-]{36}/g, "<id>")
+```
+
+## Notifications
+
+Per-message callbacks:
+
+```typescript
+const conn = new Connection({
+  url: "nats://localhost:4222",
+  serviceName: "order-service",
+
+  onNotification: ({ deliveryInfo, durationMs }) => {
+    console.log(`processed ${deliveryInfo.key} in ${durationMs}ms`);
+  },
+
+  onError: ({ deliveryInfo, error, durationMs }) => {
+    console.error(`failed ${deliveryInfo.key}: ${error.message}`);
+  },
+});
+```
+
+## Connection Monitoring
+
+NATS has built-in reconnection. Monitor connection state:
+
+```typescript
+const conn = new Connection({
+  url: "nats://localhost:4222",
+  serviceName: "order-service",
+  onDisconnect: (err) => console.error("disconnected:", err.message),
+  onReconnect: () => console.log("reconnected"),
+});
+```
+
+## Observability Across Transports
+
+The metrics and notification interfaces are identical between @sparetimecoders/messaging-amqp and @sparetimecoders/messaging-nats. The same `MetricsRecorder` implementation works with both transports — only the label values differ:
+
+| | AMQP | NATS |
+|---|------|------|
+| Consumer label value | Queue name | Consumer name |
+| Publisher label value | Exchange name | Stream name |

--- a/docs/streams.md
+++ b/docs/streams.md
@@ -1,0 +1,90 @@
+# Streams & Retention
+
+Event and custom stream patterns use **JetStream** for durable message storage. Streams need retention limits to prevent unbounded growth.
+
+## Stream Configuration
+
+### Default Retention
+
+Apply default limits to all streams:
+
+```typescript
+const conn = new Connection({
+  url: "nats://localhost:4222",
+  serviceName: "order-service",
+  streamDefaults: {
+    maxAge: 604_800_000_000_000,  // 7 days in nanoseconds
+    maxBytes: 1_073_741_824,       // 1 GiB
+    maxMsgs: 1_000_000,           // 1 million messages
+  },
+});
+```
+
+### Per-Stream Overrides
+
+```typescript
+const conn = new Connection({
+  url: "nats://localhost:4222",
+  serviceName: "order-service",
+  streamDefaults: { maxAge: 604_800_000_000_000 },
+  streamConfigs: {
+    audit: {
+      maxAge: 7_776_000_000_000_000,  // 90 days
+      maxBytes: 10_737_418_240,        // 10 GiB
+    },
+  },
+});
+```
+
+Per-stream config replaces defaults entirely for that stream (no field-level merging).
+
+### Recommended Defaults
+
+The `DefaultStreamConfig` constant provides sensible defaults:
+
+```typescript
+import { DefaultStreamConfig } from "@sparetimecoders/messaging-nats";
+
+// { maxAge: 604800000000000, maxBytes: 1073741824, maxMsgs: 1000000 }
+// 7 days, 1 GiB, 1 million messages
+```
+
+## StreamConfig Fields
+
+| Field | Type | Zero value | Description |
+|-------|------|------------|-------------|
+| `maxAge` | `number` | unlimited | Max message age (nanoseconds) |
+| `maxBytes` | `number` | unlimited | Max total size (bytes) |
+| `maxMsgs` | `number` | unlimited | Max message count |
+
+When multiple limits are set, whichever is hit first triggers cleanup.
+
+## Consumer Defaults
+
+Configure redelivery behavior for all consumers:
+
+```typescript
+const conn = new Connection({
+  url: "nats://localhost:4222",
+  serviceName: "order-service",
+  consumerDefaults: {
+    maxDeliver: 5,
+    backOff: [1000, 5000, 30000],  // milliseconds
+  },
+});
+```
+
+Per-consumer options override these defaults. See [Consumers](consumers.md).
+
+## Stream Storage
+
+All JetStream streams use **FileStorage** for durability. Streams are created automatically during `start()` when publishers or consumers are registered. If a stream already exists, its configuration is updated.
+
+## Subject Mapping
+
+Each stream accepts messages on subjects matching `{stream}.>`:
+
+| Stream | Subjects |
+|--------|----------|
+| `events` | `events.Order.Created`, `events.Payment.Completed`, ... |
+| `audit` | `audit.User.Login`, `audit.Config.Changed`, ... |

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@gomessaging/nats",
+  "name": "@sparetimecoders/messaging-nats",
   "version": "0.1.0",
   "type": "module",
   "exports": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,14 +2,14 @@
 // Copyright (c) 2026 sparetimecoders
 
 /**
- * @gomessaging/nats - NATS transport for gomessaging
+ * @sparetimecoders/messaging-nats - NATS transport for gomessaging
  *
  * This module provides a NATS transport implementation (JetStream + Core)
  * that follows the gomessaging specification for naming conventions,
  * topology, and CloudEvents binary content mode.
  *
  * Usage:
- *   import { Connection } from "@gomessaging/nats";
+ *   import { Connection } from "@sparetimecoders/messaging-nats";
  *
  *   const conn = new Connection({ url: "nats://localhost:4222", serviceName: "my-service" });
  *   const publisher = conn.addEventPublisher();

--- a/tck-adapter/nats-tck-adapter.ts
+++ b/tck-adapter/nats-tck-adapter.ts
@@ -6,7 +6,7 @@
 
 import * as fs from "node:fs";
 import * as readline from "node:readline";
-import { Connection, Publisher } from "@gomessaging/nats";
+import { Connection, Publisher } from "@sparetimecoders/messaging-nats";
 import type {
   ConsumableEvent,
   DeliveryInfo,


### PR DESCRIPTION
## Summary
- Rename npm package from `@gomessaging/nats` to `@sparetimecoders/messaging-nats`
- Update all import statements and documentation references
- Cross-repo references to amqp package also updated to new name

## Context
The package was split from the `gomessaging` mono-repo into its own repository. The package name needs to use the `@sparetimecoders` npm scope.

## Test plan
- [ ] Verify package installs correctly under new name
- [ ] Verify imports resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)