### PR TITLE
ci: re-run review gate on push

### DIFF
--- a/.github/workflows/review-gate.yaml
+++ b/.github/workflows/review-gate.yaml
@@ -2,11 +2,12 @@ name: Review Gate
 
 on:
   pull_request:
-    types: [opened, reopened]
+    types: [opened, reopened, synchronize, ready_for_review]
   pull_request_review:
     types: [submitted]
 
-permissions: {}
+permissions:
+  pull-requests: read
 
 jobs:
   review-gate:


### PR DESCRIPTION
Adds `synchronize` + `ready_for_review` to the Review Gate triggers and grants `pull-requests: read`.

The branch ruleset requires the `Review Gate` status check, but the workflow only ran on `opened`/`reopened`. Renovate rebases its branches (a `synchronize` event), producing a new head commit with no Review Gate check — so the required check is absent on the head SHA and the PR stays BLOCKED forever, even when green and approved. Re-running on `synchronize` keeps the check present on every push; `pull-requests: read` lets the approval-count lookup work on private repos.

https://claude.ai/code/session_019ckeJDoUn4QqkNAEwPqdJ8