### PR TITLE
chore(ci): allow self-hosted Renovate bot through review gate

### DIFF
--- a/.github/workflows/review-gate.yaml
+++ b/.github/workflows/review-gate.yaml
@@ -21,7 +21,7 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           REPO: ${{ github.repository }}
         run: |
-          if [ "$PR_AUTHOR" = "peter-svensson" ] || [ "$PR_AUTHOR" = "github-actions[bot]" ]; then
+          if [ "$PR_AUTHOR" = "peter-svensson" ] || [ "$PR_AUTHOR" = "github-actions[bot]" ] || [ "$PR_AUTHOR" = "stc-renovate-app[bot]" ]; then
             echo "PR by $PR_AUTHOR, no review required"
             exit 0
           fi


### PR DESCRIPTION
Adds `stc-renovate-app[bot]` to the review-gate allowlist so self-hosted Renovate PRs pass without a manual approval (matches green-checks automerge). One of 8 messaging repos with this gate.

https://claude.ai/code/session_01WvBFwZ8xJB9dtb4BxDRHxT